### PR TITLE
Bug/11

### DIFF
--- a/compute.go
+++ b/compute.go
@@ -41,7 +41,6 @@ func computeNonSigFigs(p Precision, v string, d Decimals) (string, error) {
 	if p == Exact {
 		return "", nil
 	}
-	//copy, err := highPrecisionTruncate(p, v, d)
 	copy, _, err := big.ParseFloat(v, 10, PREC_BITS, big.ToZero)
 	if err != nil {
 		return "", err

--- a/compute.go
+++ b/compute.go
@@ -41,7 +41,8 @@ func computeNonSigFigs(p Precision, v string, d Decimals) (string, error) {
 	if p == Exact {
 		return "", nil
 	}
-	copy, err := highPrecisionTruncate(p, v, d)
+	//copy, err := highPrecisionTruncate(p, v, d)
+	copy, _, err := big.ParseFloat(v, 10, PREC_BITS, big.ToZero)
 	if err != nil {
 		return "", err
 	}

--- a/digits_test.go
+++ b/digits_test.go
@@ -282,6 +282,22 @@ var testCases = []*testCase{
 			tail:       "",
 		},
 	},
+	{
+		stimulus: stimulus{
+			precision:           digits.TenThousandth,
+			value:               "1",
+			groupSeparator:      ',',
+			fractionalPrecision: digits.PreserveUpToHundredth,
+		},
+		expectation: expectation{
+			sigFigs:    "1.0000",
+			nonSigFigs: "",
+			strOut:     "1.0000",
+			head:       "",
+			core:       "1.0000",
+			tail:       "",
+		},
+	},
 	//{ // TODO BUG https://github.com/joshuanario/digits/issues/7
 	//	stimulus: stimulus{
 	//		precision:           digits.Tenth,

--- a/digits_test.go
+++ b/digits_test.go
@@ -266,6 +266,22 @@ var testCases = []*testCase{
 			tail:       "00,000.00)",
 		},
 	},
+	{
+		stimulus: stimulus{
+			precision:           digits.TenThousandth,
+			value:               "1.02",
+			groupSeparator:      ',',
+			fractionalPrecision: digits.PreserveUpToHundredth,
+		},
+		expectation: expectation{
+			sigFigs:    "1.0200",
+			nonSigFigs: "",
+			strOut:     "1.0200",
+			head:       "",
+			core:       "1.0200",
+			tail:       "",
+		},
+	},
 	//{ // TODO BUG https://github.com/joshuanario/digits/issues/7
 	//	stimulus: stimulus{
 	//		precision:           digits.Tenth,

--- a/helpers.go
+++ b/helpers.go
@@ -57,18 +57,6 @@ func lowPrecisionTruncate(p Precision, v string, d Decimals) (*big.Float, error)
 	truncated, _, err := big.ParseFloat(f, 10, PREC_BITS, big.ToZero)
 	return truncated, err
 }
-func highPrecisionTruncate(p Precision, v string, d Decimals) (*big.Float, error) {
-	prec := high(p, d)
-	i := strings.IndexRune(v, '.')
-	f := v
-	// TODO: this is where the error occurs, with index out of bounds.
-	// Consider calculating the number of appended zeros needed, then parse float, or see if parseFloat can be passed a value to set the precision.
-	if i > -1 {
-		f = v[:i+prec+1]
-	}
-	truncated, _, err := big.ParseFloat(f, 10, PREC_BITS, big.ToZero)
-	return truncated, err
-}
 func shrinker(p Precision) (*big.Float, error) {
 	if p >= Oneth || p == Exact {
 		one, _, err := big.ParseFloat("1", 10, PREC_BITS, big.ToZero)

--- a/helpers.go
+++ b/helpers.go
@@ -61,6 +61,8 @@ func highPrecisionTruncate(p Precision, v string, d Decimals) (*big.Float, error
 	prec := high(p, d)
 	i := strings.IndexRune(v, '.')
 	f := v
+	// TODO: this is where the error occurs, with index out of bounds.
+	// Consider calculating the number of appended zeros needed, then parse float, or see if parseFloat can be passed a value to set the precision.
 	if i > -1 {
 		f = v[:i+prec+1]
 	}


### PR DESCRIPTION
Current iteration fails when a specific test case is provided (see #11). Test case has been added, and initial testing with the simplification of the `highPrecisionTruncate` addresses the issue currently. All tests pass. Negligible performance impact to consider.