### PR TITLE
bug fixes

### DIFF
--- a/digits_test.go
+++ b/digits_test.go
@@ -298,6 +298,69 @@ var testCases = []*testCase{
 			tail:       "",
 		},
 	},
+	{
+		stimulus: stimulus{
+			precision:           digits.Hundredth,
+			value:               "99.3",
+			groupSeparator:      ',',
+			fractionalPrecision: digits.PreserveUpToHundredth,
+		},
+		expectation: expectation{
+			sigFigs:    "99.30",
+			nonSigFigs: "",
+			strOut:     "99.30",
+			head:       "",
+			core:       "99.30",
+			tail:       "",
+		},
+	},
+	{
+		stimulus: stimulus{
+			precision:           digits.Hundredth,
+			value:               "-99.3",
+			groupSeparator:      ',',
+			fractionalPrecision: digits.PreserveUpToHundredth,
+		},
+		expectation: expectation{
+			sigFigs:    "99.30",
+			nonSigFigs: "",
+			strOut:     "(99.30)",
+			head:       "(",
+			core:       "99.30",
+			tail:       ")",
+		},
+	}, {
+		stimulus: stimulus{
+			precision:           digits.Thousandth,
+			value:               "0.006",
+			groupSeparator:      ',',
+			fractionalPrecision: digits.PreserveUpToHundredth,
+		},
+		expectation: expectation{
+			sigFigs:    "0.006",
+			nonSigFigs: "",
+			strOut:     "0.006",
+			head:       "",
+			core:       "0.006",
+			tail:       "",
+		},
+	},
+	{
+		stimulus: stimulus{
+			precision:           digits.Thousandth,
+			value:               "-0.006",
+			groupSeparator:      ',',
+			fractionalPrecision: digits.PreserveUpToHundredth,
+		},
+		expectation: expectation{
+			sigFigs:    "0.006",
+			nonSigFigs: "",
+			strOut:     "(0.006)",
+			head:       "(",
+			core:       "0.006",
+			tail:       ")",
+		},
+	},
 	//{ // TODO BUG https://github.com/joshuanario/digits/issues/7
 	//	stimulus: stimulus{
 	//		precision:           digits.Tenth,

--- a/digits_test.go
+++ b/digits_test.go
@@ -361,22 +361,22 @@ var testCases = []*testCase{
 			tail:       ")",
 		},
 	},
-	//{ // TODO BUG https://github.com/joshuanario/digits/issues/7
-	//	stimulus: stimulus{
-	//		precision:           digits.Tenth,
-	//		value:               "80800000.99090909090",
-	//		groupSeparator:      ',',
-	//		fractionalPrecision: digits.PreserveUpToHundredth,
-	//	},
-	//	expectation: expectation{
-	//		sigFigs:    "80800000.9",
-	//		nonSigFigs: "9",
-	//		strOut:     "80,800,000.99",
-	//		head:       "",
-	//		core:       "80,800,000.9",
-	//		tail:       "9",
-	//	},
-	//},
+	{
+		stimulus: stimulus{
+			precision:           digits.Tenth,
+			value:               "80800000.99090909090",
+			groupSeparator:      ',',
+			fractionalPrecision: digits.PreserveUpToHundredth,
+		},
+		expectation: expectation{
+			sigFigs:    "80800000.9",
+			nonSigFigs: "9",
+			strOut:     "80,800,000.99",
+			head:       "",
+			core:       "80,800,000.9",
+			tail:       "9",
+		},
+	},
 }
 
 func process(stimulus stimulus) *digits.Expression {

--- a/helpers.go
+++ b/helpers.go
@@ -51,7 +51,7 @@ func lowPrecisionTruncate(p Precision, v string, d Decimals) (*big.Float, error)
 	prec := low(p, d)
 	i := strings.IndexRune(v, '.')
 	f := v
-	if i > -1 {
+	if i > -1 && len(v)-1 > i+prec+1 {
 		f = v[:i+prec+1]
 	}
 	truncated, _, err := big.ParseFloat(f, 10, PREC_BITS, big.ToZero)


### PR DESCRIPTION
Closes #14 and closes #13 

Before:
```
Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -bench ^BenchmarkSigFigs$ github.com/joshuanario/digits

goos: darwin
goarch: arm64
pkg: github.com/joshuanario/digits
BenchmarkSigFigs-10    	   22150	     52840 ns/op	   31168 B/op	    1267 allocs/op
PASS
ok  	github.com/joshuanario/digits	1.833s
```

After:
```
Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -bench ^BenchmarkSigFigs$ github.com/joshuanario/digits

goos: darwin
goarch: arm64
pkg: github.com/joshuanario/digits
BenchmarkSigFigs-10    	   18769	     62229 ns/op	   37632 B/op	    1499 allocs/op
PASS
ok  	github.com/joshuanario/digits	1.929s
```

Edit: Close #7 